### PR TITLE
v1.0.2

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun ADS1219 Arduino Library
-version=1.0.1
+version=1.0.2
 author=SparkFun Electronics
 maintainer=SparkFun Electronics
 sentence=An Arduino library for the ADS1219 24-Bit 4-Channel ADC from TI

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=An Arduino library for the ADC found on the <a href="https://www.spark
 category=Signal Input/Output
 url=https://github.com/sparkfun/SparkFun_ADS1219_Arduino_Library
 architectures=*
-depends=SparkFun_Toolkit
+depends=SparkFun Toolkit


### PR DESCRIPTION
Corrects the ```depends``` on ```SparkFun Toolkit``` in ```library.properties```.